### PR TITLE
Final preparations before 1.0 release

### DIFF
--- a/bitcart/coins/bch.py
+++ b/bitcart/coins/bch.py
@@ -12,5 +12,5 @@ class BCH(BTC):
     async def history(self) -> dict:  # pragma: no cover
         return await self.server.history()  # type: ignore
 
-    async def _addrequest(self, *args: Any, **kwargs: Any) -> dict:  # pragma: no cover
+    async def _add_request(self, *args: Any, **kwargs: Any) -> dict:  # pragma: no cover
         return await self.server.addrequest(*args, **kwargs)  # type: ignore

--- a/bitcart/coins/bch.py
+++ b/bitcart/coins/bch.py
@@ -1,6 +1,5 @@
-from typing import Optional, Union
+from typing import Any
 
-from ..utils import convert_amount_type
 from .btc import BTC
 
 
@@ -13,13 +12,5 @@ class BCH(BTC):
     async def history(self) -> dict:  # pragma: no cover
         return await self.server.history()  # type: ignore
 
-    async def addrequest(
-        self,
-        amount: Optional[Union[int, str]] = None,
-        description: str = "",
-        expire: Union[int, float] = 15,
-    ) -> dict:  # pragma: no cover
-        expiration = 60 * expire if expire else None
-        data = await self.server.addrequest(amount=amount, memo=description, expiration=expiration, force=True)
-        data[self.amount_field] = convert_amount_type(data[self.amount_field])
-        return data  # type: ignore
+    async def _addrequest(self, *args: Any, **kwargs: Any) -> dict:  # pragma: no cover
+        return await self.server.addrequest(*args, **kwargs)  # type: ignore

--- a/bitcart/coins/btc.py
+++ b/bitcart/coins/btc.py
@@ -91,10 +91,10 @@ class BTC(Coin, EventDelivery):
         data = await self.server.getbalance()
         return {attr: convert_amount_type(data.get(attr, 0)) for attr in self.BALANCE_ATTRS}
 
-    async def _addrequest(self, *args: Any, **kwargs: Any) -> dict:
+    async def _add_request(self, *args: Any, **kwargs: Any) -> dict:
         return await self.server.add_request(*args, **kwargs)  # type: ignore
 
-    async def addrequest(
+    async def add_request(
         self,
         amount: Optional[AmountType] = None,
         description: str = "",
@@ -107,32 +107,32 @@ class BTC(Coin, EventDelivery):
 
         Example:
 
-        >>> c.addrequest(0.5, "My invoice", 20)
+        >>> c.add_request(0.5, "My invoice", 20)
         {'time': 1562762334, 'amount': 50000000, 'exp': 1200, 'address': 'xxx',...
 
         Args:
             self (BTC): self
             amount (Optional[AmountType]): amount to open invoice. Defaults to None.
             description (str, optional): Description of invoice. Defaults to "".
-            expire (Union[int, float], optional): The time invoice will expire in. Defaults to 15.
+            expire (Union[int, float], optional): The time invoice will expire in. In minutes. Defaults to 15.
 
         Returns:
             dict: Invoice data
         """
         expiration = 60 * expire if expire else None
-        data = await self._addrequest(amount=amount, memo=description, expiration=expiration, force=True)
+        data = await self._add_request(amount=amount, memo=description, expiration=expiration, force=True)
         if data[self.amount_field] != "unknown":
             data[self.amount_field] = convert_amount_type(data[self.amount_field])
         return data
 
-    async def getrequest(self, address: str) -> dict:
+    async def get_request(self, address: str) -> dict:
         """Get invoice info
 
-        Get invoice information by address got from addrequest
+        Get invoice information by address got from add_request
 
         Example:
 
-        >>> c.getrequest("1A6jnc6xQwmhsChNLcyKAQNWPcWsVYqCqJ")
+        >>> c.get_request("1A6jnc6xQwmhsChNLcyKAQNWPcWsVYqCqJ")
         {'time': 1562762334, 'amount': 50000000, 'exp': 1200, 'address': '1A6jnc6xQwmhsChNLcyKAQNWPcWsVYqCqJ',...
 
         Args:

--- a/bitcart/types.py
+++ b/bitcart/types.py
@@ -1,0 +1,4 @@
+from decimal import Decimal
+from typing import Union
+
+AmountType = Union[int, str, Decimal]

--- a/bitcart/utils.py
+++ b/bitcart/utils.py
@@ -1,4 +1,6 @@
+import json
 from decimal import Decimal
+from typing import Any
 
 CONVERT_RATE = 100000000
 
@@ -37,3 +39,22 @@ def bitcoins(amount: int) -> Decimal:
         Decimal: amount in bitcoins
     """
     return Decimal(amount) / Decimal(CONVERT_RATE)
+
+
+class CustomJSONEncoder(json.JSONEncoder):
+    def default(self, obj: Any) -> Any:
+        if isinstance(obj, Decimal):
+            return str(obj)
+        return super().default(obj)  # pragma: no cover
+
+
+def json_encode(obj: Any) -> Any:
+    """json.dumps supporting Decimals
+
+    Args:
+        obj (Any): any object
+
+    Returns:
+        Any: return value of json.dumps
+    """
+    return json.dumps(obj, cls=CustomJSONEncoder)

--- a/examples/atomic_tipbot/README.md
+++ b/examples/atomic_tipbot/README.md
@@ -151,13 +151,13 @@ RPC methods accessible via btc.server can't have intellisence in your IDE becaus
 
 Now, about using BitcartCC in this bot's code.
 To get price of 1 bitcoin in USD, simply call `btc.rate()`
-Use `btc.addrequest(amount, description="", expire=15)` to create BTC invoice
+Use `btc.add_request(amount, description="", expire=15)` to create BTC invoice
 Amount is amount in BTC, description is optional and is description of invoice, expire is the time invoice will expire in, 
 default 15 minutes, but if you pass None, invoice will never expire.
 This method returns data about newly created invoice:
 
 ```
->>> btc.addrequest(0.5, "My invoice description", 20)
+>>> btc.add_request(0.5, "My invoice description", 20)
 
 {'time': 1564678098, 'amount': 1000000, 'exp': 1200, 'address': 'msS5WjurQ6AeKyAM3xHrsB4r1ACiLimoDx', 'memo': 'My invoice description', 'id': 'd46f26f3a8', 'URI': 'bitcoin:msS5WjurQ6AeKyAM3xHrsB4r1ACiLimoDx?amount=0.01', 'status': 'Pending', 'amount (BTC)': Decimal('0.01')}
 ```
@@ -176,12 +176,12 @@ Status can be one of the following:
 
 It is provided by electrum and statuses may change, as for now those statuses can be got from commands.py of electrum source, in definition of pr_str dictionary. For now it is [here](https://github.com/spesmilo/electrum/blob/master/electrum/commands.py#L604)
 
-To get status of request, we use `btc.getrequest(address)` method.
+To get status of request, we use `btc.get_request(address)` method.
 Note that we use address, not id.
 Example(when transaction is paid):
 
 ```
-btc.getrequest("msS5WjurQ6AeKyAM3xHrsB4r1ACiLimoDx")
+btc.get_request("msS5WjurQ6AeKyAM3xHrsB4r1ACiLimoDx")
 {'time': 1564678098, 'amount': 1000000, 'exp': 1200, 'address': 'msS5WjurQ6AeKyAM3xHrsB4r1ACiLimoDx', 'memo': 'My invoice description', 'id': 'd46f26f3a8', 'URI': 'bitcoin:msS5WjurQ6AeKyAM3xHrsB4r1ACiLimoDx?amount=0.01', 'status': 'Paid', 'confirmations': 0, 'amount (BTC)': Decimal('0.01')}
 ```
 

--- a/examples/atomic_tipbot/README.md
+++ b/examples/atomic_tipbot/README.md
@@ -43,8 +43,10 @@ There are two ways to do it, automatic(via docker, recommended), or directly via
 
 Clone bitcart-docker repository:
 
+```
 git clone https://github.com/MrNaif2018/bitcart-docker
 cd bitcart-docker
+```
 
 Now you need to configure BitcartCC, but if you need only BTC daemon, run those
 
@@ -52,17 +54,16 @@ Now you need to configure BitcartCC, but if you need only BTC daemon, run those
 export BITCART_INSTALL=none
 export BITCART_REVERSEPROXY=none
 ```
-If you also need to add lightning, add
 
-`export BITCART_CRYPTO2=ln`
+If you also need to add lightning, run
+
+`export BTC_LIGHTNING=true`
 
 If you need to run BTC daemon(or others, just replace BTC with coin name) in testnet, also run:
 
 `export BTC_NETWORK=testnet`
 
-After that, run  `./setup.sh`
-
-To start daemon(s), run `./start.sh`
+After that, run `./setup.sh` to configure and start daemons.
 
 If you will later need to stop them, run `./stop.sh`
 
@@ -96,7 +97,7 @@ If you need to run daemon in testnet, use:
 `BTC_NETWORK=testnet python3 daemons/btc.py`
 
 
-After that, you can run the bot using python3 bot.py and enjoy it!
+After that, you can run the bot using `python3 bot.py` and enjoy it!
 If you have come here to see how it works, read the next part.
 
 ## Reading code
@@ -129,7 +130,7 @@ BTC class accepts the following parameters:
  - rpc_user - user to login into your BitcartCC daemon
  - rpc_pass - password to login into your BitcartCC daemon
  - xpub - actually it is not just xpub, it can be x/y/z pub/prv, almost anything. Electrum seed can be used too.
- - session - completely optional, pass your precreated requests.Session(only if you need to customize something in default session)
+ - session - completely optional, pass your precreated aiohttp.ClientSession(only if you need to customize something in default session)
 
 
 After intializing coin, you can start using it.
@@ -142,15 +143,15 @@ If you need to use electrum's RPC methods, call them via btc.server(a wrapper ar
 
 Pass parameters if any, passing via keyword arguments is possible, but it is **NOT** possible to mix both keyword and
 positional arguments.
-To see a list of all RPC methods, call 
+To see a list of all RPC methods, call
 
 `btc.help()` (internally it calls `btc.server.help()`)
 
 RPC methods accessible via btc.server can't have intellisence in your IDE because they are completely dynamic(via `__getattr__`).
 
 Now, about using BitcartCC in this bot's code.
-To get price of 1 bitcoin in USD, simply call btc.rate()
-Use btc.addrequest(amount, description="", expire=15) to create BTC invoice
+To get price of 1 bitcoin in USD, simply call `btc.rate()`
+Use `btc.addrequest(amount, description="", expire=15)` to create BTC invoice
 Amount is amount in BTC, description is optional and is description of invoice, expire is the time invoice will expire in, 
 default 15 minutes, but if you pass None, invoice will never expire.
 This method returns data about newly created invoice:
@@ -158,7 +159,7 @@ This method returns data about newly created invoice:
 ```
 >>> btc.addrequest(0.5, "My invoice description", 20)
 
-{'time': 1564678098, 'amount': 1000000, 'exp': 1200, 'address': 'msS5WjurQ6AeKyAM3xHrsB4r1ACiLimoDx', 'memo': 'My invoice description', 'id': 'd46f26f3a8', 'URI': 'bitcoin:msS5WjurQ6AeKyAM3xHrsB4r1ACiLimoDx?amount=0.01', 'status': 'Pending', 'amount (BTC)': '0.01'}
+{'time': 1564678098, 'amount': 1000000, 'exp': 1200, 'address': 'msS5WjurQ6AeKyAM3xHrsB4r1ACiLimoDx', 'memo': 'My invoice description', 'id': 'd46f26f3a8', 'URI': 'bitcoin:msS5WjurQ6AeKyAM3xHrsB4r1ACiLimoDx?amount=0.01', 'status': 'Pending', 'amount (BTC)': Decimal('0.01')}
 ```
 
 time is UNIX timespamp of invoice, amount is amount in satoshis, exp is how much does invoice long(in seconds, value doesn't change),
@@ -175,73 +176,70 @@ Status can be one of the following:
 
 It is provided by electrum and statuses may change, as for now those statuses can be got from commands.py of electrum source, in definition of pr_str dictionary. For now it is [here](https://github.com/spesmilo/electrum/blob/master/electrum/commands.py#L604)
 
-To get status of request, we use btc.getrequest(address) method.
+To get status of request, we use `btc.getrequest(address)` method.
 Note that we use address, not id.
 Example(when transaction is paid):
 
 ```
 btc.getrequest("msS5WjurQ6AeKyAM3xHrsB4r1ACiLimoDx")
-{'time': 1564678098, 'amount': 1000000, 'exp': 1200, 'address': 'msS5WjurQ6AeKyAM3xHrsB4r1ACiLimoDx', 'memo': 'My invoice description', 'id': 'd46f26f3a8', 'URI': 'bitcoin:msS5WjurQ6AeKyAM3xHrsB4r1ACiLimoDx?amount=0.01', 'status': 'Paid', 'confirmations': 0, 'amount (BTC)': '0.01'}
+{'time': 1564678098, 'amount': 1000000, 'exp': 1200, 'address': 'msS5WjurQ6AeKyAM3xHrsB4r1ACiLimoDx', 'memo': 'My invoice description', 'id': 'd46f26f3a8', 'URI': 'bitcoin:msS5WjurQ6AeKyAM3xHrsB4r1ACiLimoDx?amount=0.01', 'status': 'Paid', 'confirmations': 0, 'amount (BTC)': Decimal('0.01')}
 ```
 
-If you want to keep track of invoices, you can, for now, either call getrequest in infinite loop, or use built-in method.
+If you want to keep track of invoices, you can use event system. 
 
-You can keep track of all changes to addresses on your account(all changes, not always related to invoices),
-you can use notify decorator, mark your function which you want to be capable of handling all those changes.
+You can keep track of all changes to addresses on your account, or payment request status changes.
+For that, on decorator, mark your function which you want to be capable of handling the updates with `on` decorator.
 
 ```
-@btc.notify
-def payment_handler(updates):
+@btc.on("event")
+def payment_handler(event, arg):
     # process it here
 ```
 
-By default all previous transactions on wallet are skipped(those which are below current block height).
-If you need to process every transactions always, even if was processed before(all history+new transactions), 
-pass optional skip parameter(by default it is True to skip old transactions)
+or handler for multiple events:
 
 ```
-@btc.notify(skip=False)
-def payment_handler(updates):
-    # process every address change on your wallet from it's creation
+@btc.on(["event1", "event2"])
+def payment_handler(event, arg):
+    # process it here
 ```
 
-updates is a list of updates, each element of it is a dictionary, containing two keys:
- - address - address the change(s) is related to
- - txes - list of transactions
-
-Txes is a list of dictionaries, they contain two keys:
- - tx_hash - tx_hash of transaction
- - height - block height of transaction
-
-Process it the way you need it, for example, call getrequest() on it as in our example, or use get_tx, or anything else.
+Possible events can be found at [SDK docs](https://sdk.bitcartcc.com/en/latest/events.html).
 
 To start listening for those updates, you need to start polling, for that, use:
 
 `btc.poll_updates()`
 
-But note that it is run forever(while True loop), and it blocks your code.
-In near future we will add another way of handling it(webhooks).
+Or use webhooks (starts a http server at port 6000 by default):
+
+`btc.start_webhook()`
+
+But note that it is run forever and it blocks your code.
 
 To pay to some address, use
-btc.pay_to(address, amount)
+`btc.pay_to(address, amount)`
 
-To get transaction, use btc.get_tx(tx_hash)
+To get transaction, use `btc.get_tx(tx_hash)`
+
+To accept updates for multiple coins, even in different currencies, you can use APIManager.
+
+You can read about APIManager in [SDK docs](https://sdk.bitcartcc.com/en/latest/apimanager.html).
 
 For more information, read [BitcartCC SDK docs](https://sdk.bitcartcc.com) and [Main BitcartCC docs](https://docs.bitcartcc.com)
 
 ### Telegram bot 
 
 ```
-@app.on_message(Filters.command("command_name"))
+@app.on_message(filters.command("command_name"))
 def some_func_name(client, message):
     # code here
 ```
 
 Those samples are functions corresponding to telegram commands, like /command_name in this case.
 
-If you see Filters.regex(r'pattern') it means that it is executed when it matches regex expression, and inside function
+If you see filters.regex(r'pattern') it means that it is executed when it matches regex expression, and inside function
 message.matches is available to get matches as by re.search
-Filters.private means that command works only in private chat
+filters.private means that command works only in private chat
 
 withdraw function is responsible for handling messages like this:
 **181AUpDVRQ3JVcb9wYLzKz2C8Rdb5mDeH7 500**

--- a/examples/atomic_tipbot/bot.py
+++ b/examples/atomic_tipbot/bot.py
@@ -318,7 +318,7 @@ def convert_amounts(currency, amount):
 def generate_invoice(user_id, currency, amount, amount_sat, description=""):
     amount, friendly_name = convert_amounts(currency, amount)
     # bitcart: create invoice
-    invoice = instances[currency].addrequest(amount, description, expire=20160)  # 14 days
+    invoice = instances[currency].add_request(amount, description, expire=20160)  # 14 days
     amount_field = instances[currency].amount_field  # bitcart: each coin object provides amount_field
     invoice[amount_field] = str(invoice[amount_field])  # convert to str for mongodb
     invoice.update({"user_id": user_id, "currency": currency, "original_amount": amount_sat})
@@ -386,7 +386,7 @@ async def payment_handler(instance, event, address, status, status_str):  # asyn
     inv = mongo.invoices.find({"address": address}).limit(1).sort([("$natural", -1)])[0]  # to get latest result
     if inv and inv["status"] != "Paid":
         # bitcart: get invoice info, not neccesary here
-        # btc.getrequest(address)
+        # btc.get_request(address)
         if status_str == "Paid":
             user = mongo.users.find_one({"user_id": inv["user_id"]})
             amount = inv["original_amount"]

--- a/examples/atomic_tipbot/bot.py
+++ b/examples/atomic_tipbot/bot.py
@@ -1,22 +1,27 @@
+import asyncio
 import configparser
+import logging
 import os
 import re
 import secrets
-import threading
 import time
 import traceback
 from datetime import datetime, timedelta
+from decimal import ROUND_UP, Decimal
 
 import pymongo
 import qrcode
 import qrcode.image.svg
-from pyrogram import Client, Filters, InlineKeyboardButton, InlineKeyboardMarkup
+from aiohttp import web
+from pyrogram import Client, filters
 from pyrogram.errors import BadRequest
 from pyrogram.session import Session
+from pyrogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 
 # BTC class for BTC coin, the same for others, just replace the name
 # for litecoin just import LTC
-from bitcart import BCH, BSTY, BTC, GZRO, LTC
+from bitcart import BCH, BSTY, BTC, GZRO, LTC, APIManager
+from bitcart.utils import bitcoins
 
 # Don't show message
 Session.notice_displayed = True
@@ -58,16 +63,17 @@ gzro = GZRO(xpub=XPUB)
 bsty = BSTY(xpub=XPUB)
 # same api, so we can do this
 instances = {"btc": btc, "bch": bch, "ltc": ltc, "gzro": gzro, "bsty": bsty}
+manager = APIManager({currency.upper(): [coin.xpub] for currency, coin in instances.items()})  # bitcart: create APIManager
 satoshis_hundred = 0.000001
 
 # misc
 
-deposit_select_filter = Filters.create(lambda _, cbq: bool(re.match(r"^deposit_", cbq.data)))
-deposit_filter = Filters.create(lambda _, cbq: bool(re.match(r"^pay_", cbq.data)))
-bet_filter = Filters.create(lambda _, cbq: bool(re.match(r"^bet_", cbq.data)))
-paylink_filter = Filters.create(lambda _, cbq: bool(re.match(r"^pl_", cbq.data)))
-paylink_pay_filter = Filters.create(lambda _, cbq: bool(re.match(r"^plp_", cbq.data)))
-pagination_filter = Filters.create(lambda _, cbq: bool(re.match(r"^page_", cbq.data)))
+deposit_select_filter = filters.create(lambda _, __, query: bool(re.match(r"^deposit_", query.data)))
+deposit_filter = filters.create(lambda _, __, query: bool(re.match(r"^pay_", query.data)))
+bet_filter = filters.create(lambda _, __, query: bool(re.match(r"^bet_", query.data)))
+paylink_filter = filters.create(lambda _, __, query: bool(re.match(r"^pl_", query.data)))
+paylink_pay_filter = filters.create(lambda _, __, query: bool(re.match(r"^plp_", query.data)))
+pagination_filter = filters.create(lambda _, __, query: bool(re.match(r"^page_", query.data)))
 
 
 class Paginator:
@@ -101,6 +107,10 @@ def get_user_data(user_id):
         }
         mongo.users.insert_one(user)
     return user
+
+
+def round_usd(d):
+    return d.quantize(Decimal(".01"), rounding=ROUND_UP)  # round to two digits
 
 
 def change_balance(user_id, amount, tx_type, tx_hash=None, address=None):
@@ -164,10 +174,10 @@ def paylink_kb(currency, amount):
     return InlineKeyboardMarkup(keyboard)
 
 
-@app.on_message(Filters.command("help"))
+@app.on_message(filters.command("help"))
 def help_handler(client, message):
     # bitcart: get usd price
-    usd_price = round(btc.rate() * satoshis_hundred, 2)
+    usd_price = round(btc.rate() * Decimal(satoshis_hundred), 2)  # we use Decimals for accuracy
     message.reply(
         f"""
 <b>In development, now working commands are tip!xxx, /start, /help, /deposit, /balance, /send, /history, /send2telegram,
@@ -220,7 +230,7 @@ def paylink_pay_kb(deposit_id, amount):
     return InlineKeyboardMarkup(keyboard)
 
 
-@app.on_message(Filters.command("start"))
+@app.on_message(filters.command("start"))
 def start(client, message):
     # quote=False with reply is just a shorter version of
     # app.send_message(chat_id, message)
@@ -267,13 +277,13 @@ def pay_paylink(client, message):
         message.edit_message_text("Paylink canceled.")
 
 
-@app.on_message(Filters.command("balance"))
+@app.on_message(filters.command("balance"))
 def balance(client, message):
     user_data = get_user_data(message.from_user.id)
     message.reply(f"Your balance is {user_data['balance']} satoshis")
 
 
-@app.on_message(Filters.command("deposit") & Filters.private)
+@app.on_message(filters.command("deposit") & filters.private)
 def deposit(client, message):
     message.reply(
         "Choose amount you want to deposit:",
@@ -309,6 +319,8 @@ def generate_invoice(user_id, currency, amount, amount_sat, description=""):
     amount, friendly_name = convert_amounts(currency, amount)
     # bitcart: create invoice
     invoice = instances[currency].addrequest(amount, description, expire=20160)  # 14 days
+    amount_field = instances[currency].amount_field  # bitcart: each coin object provides amount_field
+    invoice[amount_field] = str(invoice[amount_field])  # convert to str for mongodb
     invoice.update({"user_id": user_id, "currency": currency, "original_amount": amount_sat})
     mongo.invoices.insert_one(invoice)
     return invoice, amount, friendly_name
@@ -319,7 +331,7 @@ def deposit_query(client, call):
     call.edit_message_text("Okay, almost done! Now generating invoice...")
     _, currency, amount = call.data.split("_")
     amount_sat = int(amount)
-    amount_btc = amount_sat * 0.00000001
+    amount_btc = bitcoins(amount_sat)  # bitcart: convert satoshis to bitcoins
     user_id = call.from_user.id
     invoice, amount, _ = generate_invoice(user_id, currency, amount_btc, amount_sat, f"{secret_id(user_id)} top-up")
     send_qr(
@@ -330,7 +342,7 @@ def deposit_query(client, call):
     )
 
 
-@app.on_message(Filters.private & Filters.command("paylink"))
+@app.on_message(filters.private & filters.command("paylink"))
 def paylink(client, message):
     try:
         _, currency, amount_sat = message.command
@@ -349,7 +361,7 @@ def paylink_query(client, message):
     user_id = message.from_user.id
     _, link_type, currency, amount_sat = message.data.split("_")
     amount_sat = int(amount_sat)
-    amount_btc = amount_sat / 100000000
+    amount_btc = bitcoins(amount_sat)
     amount, currency_name = convert_amounts(currency, amount_btc)
     if link_type == "pr":
         invoice, _, _ = generate_invoice(user_id, currency, amount_btc, amount_sat, f"{secret_id(user_id)} paylink")
@@ -368,13 +380,9 @@ def paylink_query(client, message):
         pass
 
 
-# After addition of APIManager this should get even easier
-@btc.on("new_payment")
-@bch.on("new_payment")
-@ltc.on("new_payment")
-@gzro.on("new_payment")
-@bsty.on("new_payment")
-def payment_handler(event, address, status, status_str):
+# Register event handler for all coins in a manager
+@manager.on("new_payment")
+async def payment_handler(instance, event, address, status, status_str):  # async to make pyrogram sending work
     inv = mongo.invoices.find({"address": address}).limit(1).sort([("$natural", -1)])[0]  # to get latest result
     if inv and inv["status"] != "Paid":
         # bitcart: get invoice info, not neccesary here
@@ -385,10 +393,10 @@ def payment_handler(event, address, status, status_str):
             new_balance = user["balance"] + amount
             mongo.invoices.update_one({"address": address}, {"$set": {"status": "Paid"}})
             change_balance(inv["user_id"], amount, "deposit", address=address)
-            app.send_message(
+            await app.send_message(
                 user["user_id"],
                 f"{amount} Satoshis added to your balance. Your balance: {new_balance}",
-            )
+            )  # we await here as function is async
 
 
 def secret_id(user_id):
@@ -396,7 +404,7 @@ def secret_id(user_id):
     return f"{user_id[:3]}-{user_id[-3:]}"
 
 
-@app.on_message(Filters.command("top"))
+@app.on_message(filters.command("top"))
 def top(client, message):
     userlist = mongo.users.find().sort("balance", pymongo.DESCENDING).limit(10)
     balance = get_user_data(message.from_user.id)["balance"]
@@ -416,7 +424,7 @@ def top(client, message):
     message.reply(msg, quote=False)
 
 
-@app.on_message(Filters.private & Filters.command("send"))
+@app.on_message(filters.private & filters.command("send"))
 def send(client, message):
     message.reply(
         """
@@ -427,7 +435,7 @@ btc 181AUpDVRQ3JVcb9wYLzKz2C8Rdb5mDeH7 500
     )
 
 
-@app.on_message(Filters.reply & Filters.regex(r"[Tt]ip!([0-9]+)"))
+@app.on_message(filters.reply & filters.regex(r"[Tt]ip!([0-9]+)"))
 def tip(client, message):
     reply_id = message.reply_to_message.from_user.id
     user_id = message.from_user.id
@@ -460,7 +468,7 @@ def tip(client, message):
         pass
 
 
-@app.on_message(Filters.private & Filters.text & Filters.regex(r"(\w+) (\w+) (\d+)"))
+@app.on_message(filters.private & filters.text & filters.regex(r"(\w+) (\w+) (\d+)"))
 def withdraw(client, message):
     user_id = message.from_user.id
     currency = message.matches[0].group(1)
@@ -475,13 +483,12 @@ def withdraw(client, message):
     user = get_user_data(user_id)
     if amount <= 0 or user["balance"] < amount:
         return message.reply("Not enough balance", quote=False)
-    amount_btc = amount / 100000000
-    amount_to_send = amount_btc / coin_obj.rate("BTC")
-    wallet_balance = float(coin_obj.balance()["confirmed"])  # TODO: investigate why it is a string
+    amount_to_send = bitcoins(amount) / coin_obj.rate("BTC")
+    wallet_balance = coin_obj.balance()["confirmed"]
     if wallet_balance < amount_to_send:
         available_coins = []
         for coin in instances:
-            coin_balance = float(instances[coin].balance()["confirmed"])
+            coin_balance = instances[coin].balance()["confirmed"]
             if coin_balance >= amount_to_send:
                 available_coins.append(instances[coin].coin_name)
         wallet_balance_sat = int(round(wallet_balance * coin_obj.rate("BTC") * 100000000, 8))
@@ -517,7 +524,7 @@ def render_history_page(paginator, page):
     return msg
 
 
-@app.on_message(Filters.private & Filters.command("history"))
+@app.on_message(filters.private & filters.command("history"))
 def history(client, message):
     query = {"user_id": message.from_user.id}
     msg = "Transaction history:\n"
@@ -594,7 +601,7 @@ def make_bet(userid, currency, amount, trend, set_time, chat_id, msg_id):
 
         win_amount = int(round(amount * coef))
 
-        price = instances[currency].rate("USD")
+        price = round_usd(instances[currency].rate("USD"))
 
         recorddate = datetime.strptime(dtime, DATE_FORMAT)
 
@@ -608,7 +615,7 @@ def make_bet(userid, currency, amount, trend, set_time, chat_id, msg_id):
             "chat_id": chat_id,
             "msg_id": msg_id,
             "trend": trend,
-            "price": price,
+            "price": str(price),  # convert for mongodb
             "status": "new",
             "timeout": set_time,
             "userid": userid,
@@ -623,7 +630,7 @@ def make_bet(userid, currency, amount, trend, set_time, chat_id, msg_id):
             chat_id=chat_id,
             text=(
                 f"Your {amount} sat bet is accepted, hodler! You will receive {win_amount} if {coin_name} price go {trend}"
-                f" from {price:.8f}@Coingecko in a {set_time}"
+                f" from {price:.2f}@Coingecko in a {set_time}"
             ),
             reply_to_message_id=msg_id,
         )
@@ -644,7 +651,7 @@ def make_bet(userid, currency, amount, trend, set_time, chat_id, msg_id):
         return False
 
 
-@app.on_message(Filters.command("bet"))
+@app.on_message(filters.command("bet"))
 def bet(client, message):
     try:
         _, currency, amount, trend, date = message.command
@@ -698,7 +705,7 @@ def genvoucher(user_id, amount, receiver):
     return voucher
 
 
-@app.on_message(Filters.command("send2telegram"))
+@app.on_message(filters.command("send2telegram"))
 def send2telegram(client, message):
     user_id = message.from_user.id
     try:
@@ -720,7 +727,7 @@ def send2telegram(client, message):
         message.reply("Failed to send funds. Command format to send 10000 to @MrNaif_bel: /send2telegram @MrNaif_bel 10000")
 
 
-@app.on_message(Filters.private & Filters.command("claim"))
+@app.on_message(filters.private & filters.command("claim"))
 def claim(client, message):
     user_id = message.from_user.id
     get_user_data(user_id)
@@ -740,19 +747,25 @@ def claim(client, message):
     message.reply(f"{count} vouchers redeemed for {sum_} satoshi in total")
 
 
-def betcheck(first=False):
-    if first:
-        time.sleep(10)
-    threading.Timer(30.0, betcheck).start()
+async def betcheck_schedule():
+    await asyncio.sleep(10)
+    while True:
+        try:
+            await betcheck()
+        except Exception as e:
+            logging.error(e)  # log error
+        await asyncio.sleep(30)
 
+
+async def betcheck():
     # check bets
     bets = mongo.bets.find({"status": "new"}).sort("amount", pymongo.DESCENDING).limit(10)
 
-    prices = {currency: instances[currency].rate("USD") for currency in instances}  # dict comprehension
-
+    prices = {currency: round_usd(await instances[currency].rate("USD")) for currency in instances}  # dict comprehension
     for bet in bets:
         now_time = datetime.now()
         bet_exp = bet["unixtime_exp"]
+        bet["price"] = Decimal(bet["price"])  # convert from str in db to python decimal
         price = prices[bet["currency"]]
         if bet_exp < now_time:
             if bet["trend"] == "up":
@@ -763,31 +776,39 @@ def betcheck(first=False):
                 win = bet["price"] == price
             if win:
                 change_balance(bet["userid"], bet["win"], "bet win")
-                app.send_animation(
+                await app.send_animation(
                     chat_id=bet["userid"],
                     animation="https://i.imgur.com/bZAS9ac.gif",
-                    caption=f"Congratulations! You won {bet['win']} satoshis! {bet['price']:.8f} {bet['trend']} {price:.8f}",
+                    caption=f"Congratulations! You won {bet['win']} satoshis! {bet['price']:.2f} {bet['trend']} {price:.2f}",
                 )
-                app.send_message(
+                await app.send_message(
                     chat_id=bet["chat_id"],
                     text=f'Someone just won {bet["win"]} satoshis on bets!',
                     reply_to_message_id=bet["msg_id"],
                 )
             else:
-                app.send_animation(
+                await app.send_animation(
                     chat_id=bet["userid"],
                     animation="https://i.imgur.com/2bmpZsM.gif",
-                    caption=f"Your bet wasn't lucky one! Bet on {bet['price']:.8f} {bet['trend']}, but price is {price:.8f}",
+                    caption=f"Your bet wasn't lucky one! Bet on {bet['price']:.2f} {bet['trend']}, but price is {price:.2f}",
                 )
             mongo.bets.update_one({"_id": bet["_id"]}, {"$set": {"status": "expired"}})
-        time.sleep(1)
+        await asyncio.sleep(1)
 
 
-threading.Thread(target=betcheck, kwargs={"first": True}).start()
-# Starting polling for all coins, with APIManager this should get easier
-threading.Thread(target=btc.poll_updates).start()  # or .start_webhook()
-threading.Thread(target=bch.poll_updates).start()
-threading.Thread(target=ltc.poll_updates).start()
-threading.Thread(target=gzro.poll_updates).start()
-threading.Thread(target=bsty.poll_updates).start()
-app.start()
+async def start_webhook():
+    await manager.configure_webhook()  # bitcart: setup aiohttp app and notify daemon of it
+    # aiohttp app setup in async context
+    runner = web.AppRunner(manager.webhook_app)
+    await runner.setup()
+    site = web.TCPSite(runner, "localhost", 6000)
+    await site.start()
+
+
+# NOTE: never use threading with asyncio, .create_task should be used instead!
+
+loop = asyncio.get_event_loop()
+loop.create_task(betcheck_schedule())
+loop.create_task(start_webhook())  # bitcart: start webhook to listen for new payments on all coins
+
+app.run()

--- a/examples/donateto.py
+++ b/examples/donateto.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # A command line utility to send to some address from your wallet
 import sys
+from decimal import Decimal, InvalidOperation
 
 from bitcart import BTC, errors
 from bitcart.errors import ConnectionFailedError
@@ -11,8 +12,8 @@ if len(sys.argv) != 4:
 xpub = sys.argv[1]
 address = sys.argv[2]
 try:
-    amount = float(sys.argv[3])
-except ValueError:
+    amount = Decimal(sys.argv[3])
+except InvalidOperation:
     print("Invalid amount passed")
     sys.exit(1)
 # bitcartcc-related code

--- a/examples/full.py
+++ b/examples/full.py
@@ -32,10 +32,10 @@ btc2 = BTC(xpub="paste your x/y/z pub/prv or electrum seed here for it to work")
 print(btc2.balance())
 print(btc2.history())  # history of all transactions and summary
 ### Payment requests ###
-data = btc2.addrequest(0.5)
+data = btc2.add_request(0.5)
 print(data)
-print(btc2.addrequest(0.5, "Any description"))  # Request specified amount in BTC
-print(btc2.getrequest(data["address"]))  # Check request status
+print(btc2.add_request(0.5, "Any description"))  # Request specified amount in BTC
+print(btc2.get_request(data["address"]))  # Check request status
 ### Sending ###
 if DONATE_TO_AUTHOR:
     print(btc2.pay_to("1A6jnc6xQwmhsChNLcyKAQNWPcWsVYqCqJ", 0.1))  # tx hash returned

--- a/examples/getbalance.py
+++ b/examples/getbalance.py
@@ -13,6 +13,6 @@ xpub = sys.argv[1]
 btc = BTC(xpub=xpub)
 try:
     balance = btc.balance()
-    print(f"Onchain balance: {balance['confirmed']}\nOffchain balance:{balance['lightning']}")
+    print(f"Onchain balance: {balance['confirmed']}\nOffchain balance: {balance['lightning']}")
 except (RequestError, ConnectionFailedError):
     print("Bad wallet provided, or daemon not running.")

--- a/tests/coins/btc/test_with_wallet.py
+++ b/tests/coins/btc/test_with_wallet.py
@@ -24,15 +24,15 @@ async def test_history(btc_wallet):
 async def test_payment_request(btc_wallet):
     # request1
     request1_amount = "0.5"
-    request1 = await btc_wallet.addrequest(request1_amount)
+    request1 = await btc_wallet.add_request(request1_amount)
     assert request1[btc_wallet.amount_field] == request1["amount_BTC"] == Decimal(request1_amount)
     # request2
     request2_amount, request2_desc = "0.6", "test description"
-    request2 = await btc_wallet.addrequest(request2_amount, request2_desc)
+    request2 = await btc_wallet.add_request(request2_amount, request2_desc)
     assert request2["amount_BTC"] == Decimal(request2_amount)
     assert request2["memo"] == request2_desc
     # get request2
-    response2 = await btc_wallet.getrequest(request2["address"])
+    response2 = await btc_wallet.get_request(request2["address"])
     assert response2["amount_BTC"] == Decimal(request2_amount)
     assert response2["memo"] == request2_desc
 

--- a/tests/regtest.py
+++ b/tests/regtest.py
@@ -8,7 +8,7 @@ from .utils import data_check, run_shell
 
 pytestmark = pytest.mark.asyncio
 
-BTC_ADDRESS = "mjHXzpMTjhLePAdWgoesdhqEzCCRh6mwkJ"  # can be got by run_shell(["newaddress"]) or regtest_wallet.addrequest()
+BTC_ADDRESS = "mjHXzpMTjhLePAdWgoesdhqEzCCRh6mwkJ"  # can be got by run_shell(["newaddress"]) or regtest_wallet.add_request()
 
 TEST_PARAMS = [
     (None, None, True),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,5 +30,5 @@ def test_convert_amount_type():
 @pytest.mark.asyncio
 async def test_decimal_sending(btc_wallet):
     amount = Decimal("0.5")
-    req = await btc_wallet.addrequest(amount)  # ensures that it is possible to pass decimal
+    req = await btc_wallet.add_request(amount)  # ensures that it is possible to pass decimal
     assert req[btc_wallet.amount_field] == amount

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,3 +25,10 @@ def test_convertability():
 
 def test_convert_amount_type():
     assert convert_amount_type("1") == Decimal("1")
+
+
+@pytest.mark.asyncio
+async def test_decimal_sending(btc_wallet):
+    amount = Decimal("0.5")
+    req = await btc_wallet.addrequest(amount)  # ensures that it is possible to pass decimal
+    assert req[btc_wallet.amount_field] == amount


### PR DESCRIPTION
This is the first part of final preparations before 1.0 release
This PR:
- adds `json_encode` function to utils, and allows sending Decimals via .server functions
- refactors `addrequest` to maximize code sharing between `btc.py` and `bch.py`
- Fixes a bug in decimal conversion when amount is None
- Adds new `AmountType` type, which is `Union[int, str, Decimal]` - it is used in all amount or fee arguments
- In sync code, fallbacks to main event loop if no event loop is found in current thread
- Upgrades atomic tipbot example to pyrogram 1.0 and latest SDK changes

Things to also consider changing:
- Maybe `addrequest` and `getrequest` should be renamed to follow PEP8 and other function conventions, as release 1.0 is breaking anyway