### PR TITLE
Electrum 4.0.3 upgrade and 1.0 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,14 @@ jobs:
           background: true
 
       - run:
+          name: prepare regtest lightning node
+          command: |
+            . ~/venv/bin/activate
+            cd ~/bitcart-daemon
+            make regtestln
+          background: true
+
+      - run:
           name: run regtest tests
           command: |
             . ~/venv/bin/activate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
             cd ~/repo
             sudo apt install libsecp256k1-dev
             pip install electrumx
-            git clone https://github.com/bitcartcc/bitcart ~/bitcart-daemon -b electrum-4.0.3 # TODO: remove when merging
+            git clone https://github.com/bitcartcc/bitcart ~/bitcart-daemon
             cd ~/bitcart-daemon
             pip install -r requirements/base.txt
             pip install -r requirements/daemons/btc.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
             cd ~/repo
             sudo apt install libsecp256k1-dev
             pip install electrumx
-            git clone https://github.com/bitcartcc/bitcart ~/bitcart-daemon
+            git clone https://github.com/bitcartcc/bitcart ~/bitcart-daemon -b electrum-4.0.3 # TODO: remove when merging
             cd ~/bitcart-daemon
             pip install -r requirements/base.txt
             pip install -r requirements/daemons/btc.txt

--- a/.coveragerc
+++ b/.coveragerc
@@ -10,6 +10,5 @@ omit =
 [report]
 exclude_lines =
     pragma: no cover
-    if not webhook_available:
     raise NotImplementedError()
     if TYPE_CHECKING:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,10 @@ As async and sync versions are now part of one library, it will be in `bitcart` 
 
 All future updates will be made in `bitcart` package.
 
+#### Breaking changes in electrum format
+
+They can be found in this PR [comment](https://github.com/bitcartcc/bitcart-sdk/pull/17#issuecomment-700143843)
+
 ## 0.9.1
 
 Fixed async timeouts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,297 @@
+# Release Notes
+
+## Latest changes
+
+## 0.9.1
+
+Fixed async timeouts
+Fixed timeout from 10 seconds to 5 minutes
+
+## 0.9.0
+
+To use proxy, install optional dependencies:
+
+`pip install bitcart[proxy]` for sync version, `pip install bitcart-async[proxy]` for async version.
+
+HTTP, SOCKS4 and SOCKS5 proxies supported.
+
+To use, pass proxy url to coin constructor:
+
+```python
+btc = BTC(proxy="socks5://localhost:9050")
+```
+
+
+
+## 0.8.5
+
+Version 0.8.5: completely remove aiohttp warnings
+
+This version removes a nasty unclosed session and connector warning, finally!
+
+## 0.8.4
+
+Bitcoin Cash support & misc fixes
+
+This version adds bitcoin cash support plus probably forever fixes unclosed session warning (:
+
+## 0.8.3
+
+Added BSTY coin
+
+## 0.8.2
+
+Added validate_key method
+
+You can now use validate_key method to ensure that key you are going to use restore wallet is valid, without actually restoring it.
+
+Examples:
+
+```python
+>>> c.validate_key("test")
+False
+
+>>> c.validate_key("your awesome electrum seed")
+True
+
+>>> c.validate_key("x/y/z pub/prv here")
+True
+```
+
+## 0.8.1
+
+Webhooks!
+
+This update adds a new way of receiving updates, start a webhook and daemon will deliver updates to that webhook by itself.
+
+To use that feature, `pip install bitcart[webhook]` for sync version(flask), async version has that built-in(aiohttp).
+
+To use that instead of polling, just replace
+`btc.poll_updates()`
+with
+`btc.start_webhook()`
+
+## 0.8.0.post4
+
+Remove async warning
+
+This is a follow-up of previous release
+
+## 0.8.0.post3
+
+Automatic session closing in async!
+
+That's it, no need to use async with or manual .close() anymore in async version!
+
+## 0.8.0.post2
+
+Added missing event and history() fixes
+
+## 0.8.0.post1
+
+This bugfix fixes xpub sending, and exception raising.
+
+## 0.8.0
+
+Structural improvements and more
+
+**Structural improvements**
+
+This version makes async version the default one used in the repo.
+
+Pypi versions aren't changed, bitcart is sync version, bitcart-async is async.
+
+But now there is a major difference, instead of maintaining both sync and async versions,
+async version is in master, and sync version is generated using `sync_generator.py`, which basically removes async's and awaits.
+
+It means less time spent, and instead of porting new features to sync/async versions, now I will have more time spend on new features!
+
+The async branch will be deleted.
+
+**Sending transactions improvements**
+
+Also, the long awaited `pay_to_many` function to do batch transactions is there!
+Both `pay_to` and `pay_to_many` now have optional `feerate`, which is sat/vbyte rate.
+
+Minimum possible is 1 sat/vbyte.
+
+With bitcart you can get minimal fees, with no third parties!
+
+## 0.6.3
+
+Added support for both args and kwargs, fixes
+This version allows using SDK with both positional and by-name arguments.
+
+## 0.6.2
+
+Added missing pay_to_many
+
+This release adds ability to create batch transactions, some examples:
+
+```python
+>>> btc.pay_to_many([{"address":"mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt","amount":0.001}, {"address":"mv4rnyY3Su5gjcDNzbMLKBQkBicCtHUtFB","amount":0.0001}])
+'60fa120d9f868a7bd03d6bbd1e225923cab0ba7a3a6b961861053c90365ed40a'
+
+ >>> btc.pay_to_many([("mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt",0.001),("mv4rnyY3Su5gjcDNzbMLKBQkBicCtHUtFB",0.0001)])
+'d80f14e20af2ceaa43a8b7e15402d420246d39e235d87874f929977fb0b1cab8'
+
+>>> btc.pay_to_many([("mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt",0.001), ("mv4rnyY3Su5gjcDNzbMLKBQkBicCtHUtFB",0.0001)], broadcast=False)
+{'hex': '0200000...', 'complete': True, 'final': False}
+```
+
+
+## 0.6.1
+
+Fix for latest daemon
+
+## 0.6.0
+
+This version adds new coin: gzro to bitcart.
+All APIs are the same, just import GZRO from bitcart.
+
+## 0.5.1
+
+Fee calculation func now recieves default fee as argument too
+
+## 0.5.0
+
+This version adds new coin: litecoin to bitcart.
+
+This is where bitcart shows its features.
+
+All APIs are the same, just import LTC from bitcart.
+
+## 0.4.0
+
+Full fee control and easy lightning.
+
+Fee control:
+
+Now you can pass fee parameter to pay_to function to specify manual fee, or
+callback function like:
+
+```python
+def fee_calc(size):
+    return size/4
+btc.pay_to(address, amount, fee=fee_calc)
+```
+
+Getting size as argument and returning fee, it can be any function of your choice.
+
+Another parameter, broadcast, was added. By default transaction is submitted to network, but if you set broadcast to False raw transaction will be returned. See API reference in docs for details.
+
+**Easy lightning:**
+
+Now lightning is part of btc daemon and BTC coin class, just launch the same daemon and use all lightning functions!
+
+After upgrade, try for example, this:
+
+```python
+>>> btc.node_id
+'030ff29580149a366bdddf148713fa808f0f4b934dccd5f7820f3d613e03c86e55'
+```
+
+Lightning is enabled in your daemon by default, disable it with BTC_LIGTNING=false environment variable.
+
+If lightning is disabled, `bitcart.errors.LightningDisabledError` is raised.
+
+
+## 0.3.0
+
+This version adds new events-based API to get updates.
+
+To register a callback function, use `add_event_handler(events, func)` function or `@on` decorator
+
+Example:
+
+```python
+@btc.on("new_transaction")
+def handler(event, tx):
+    print(event)
+    print(tx)
+    print(btc.get_tx(tx))
+btc.poll_updates()
+```
+
+The following code would print
+
+```
+new_transaction
+some_tx_hash
+dict of tx hash data
+```
+
+On each transaction in your wallet.
+`btc.on` or `add_event_handler` can also accept a list of events, for example:
+
+```python
+def handler(event, **kwargs):
+    print(event, kwargs)
+```
+
+Getting updates is the same, via `btc.poll_updates()`.
+
+There are two kinds of events for now:
+
+`new_block` which gets emitted on every new block, passing height argument to callback function
+
+`new_transaction` which gets emitted on every new transaction passing tx argument as tx_hash of new transaction to callback_function.
+
+Old `@btc.notify` api is removed.
+
+
+## 0.2.5
+
+Fix warning raising(no stacklevel)
+
+## 0.2.4
+
+Added ability to get fiat price in most currencies
+
+Now `rate()` method accepts optional currency argument to get it in currency other than USD.
+
+New method: `list_fiat()` to get list of all supported fiat currencies.
+
+## 0.2.3
+
+Add `btc.rate()` method to get USD price of bitcoin
+
+## 0.2.2
+
+Use requests.Session for better performance
+
+## 0.2.1
+
+This is a small bugfix to fix pip description rendering.
+
+## 0.2.0
+
+Version 0.2.0: Lightning update!
+
+Lightning network support is now in bitcart as defined by [bitcartcc/bitcart#51](https://github.com/bitcartcc/bitcart/pull/51)
+
+This adds in new LN class and related methods.
+
+Also, now it is not needed to fill in all values, some defaults are used:
+
+```
+rpc_user="electrum"
+rpc_pass="electrumz"
+rpc_url="http://localhost:5000" for bitcoin daemon and "http://localhost:5001" for lightning daemon.
+```
+
+When xpub is not provided, a warning is created.
+
+
+## 0.1.4
+
+- Add type hints everywhere
+- Code is checked with mypy and pylint
+- Docs now available(check readme)
+- Automatic deployment via circleci
+
+And many more...
+
+## 0.1
+
+Initial release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,8 @@ Run `make bitcoind` to start bitcoind, `make electrumx` to start electrumx.
 
 After that, stop your mainnet BitcartCC daemon, and start regtest one from cloned `bitcart` repo by running `make regtest`.
 
+You should also start an lightning node for testing, run `make regtestln` in another terminal.
+
 To run extended test suite, run `make regtest`.
 
 Coverage from extended test suite is appended to main test coverage.

--- a/bitcart/coins/bch.py
+++ b/bitcart/coins/bch.py
@@ -9,5 +9,8 @@ class BCH(BTC):
     RPC_URL = "http://localhost:5004"
     AMOUNT_FIELD = "amount (BCH)"
 
+    async def history(self) -> dict:  # pragma: no cover
+        return await self.server.history()  # type: ignore
+
     async def _add_request(self, *args: Any, **kwargs: Any) -> dict:  # pragma: no cover
         return await self.server.addrequest(*args, **kwargs)  # type: ignore

--- a/bitcart/coins/bch.py
+++ b/bitcart/coins/bch.py
@@ -9,8 +9,5 @@ class BCH(BTC):
     RPC_URL = "http://localhost:5004"
     AMOUNT_FIELD = "amount (BCH)"
 
-    async def history(self) -> dict:  # pragma: no cover
-        return await self.server.history()  # type: ignore
-
     async def _add_request(self, *args: Any, **kwargs: Any) -> dict:  # pragma: no cover
         return await self.server.addrequest(*args, **kwargs)  # type: ignore

--- a/bitcart/coins/btc.py
+++ b/bitcart/coins/btc.py
@@ -344,8 +344,7 @@ class BTC(Coin, EventDelivery):
         Returns:
             Decimal: price of 1 bitcoin in selected fiat currency
         """
-        rate_str = await self.server.exchange_rate(currency)
-        return convert_amount_type(rate_str)
+        return convert_amount_type(await self.server.exchange_rate(currency))
 
     async def list_fiat(self) -> Iterable[str]:
         """List of all available fiat currencies to get price for

--- a/bitcart/coins/btc.py
+++ b/bitcart/coins/btc.py
@@ -120,7 +120,7 @@ class BTC(Coin, EventDelivery):
         """
         expiration = 60 * expire if expire else None
         data = await self._add_request(amount=amount, memo=description, expiration=expiration, force=True)
-        if data[self.amount_field] != "unknown":
+        if data[self.amount_field].lower() != "unknown":
             data[self.amount_field] = convert_amount_type(data[self.amount_field])
         return data
 
@@ -142,7 +142,7 @@ class BTC(Coin, EventDelivery):
             dict: Invoice data
         """
         data = await self.server.getrequest(address)
-        if data[self.amount_field] != "unknown":
+        if data[self.amount_field].lower() != "unknown":
             data[self.amount_field] = convert_amount_type(data[self.amount_field])
         return data  # type: ignore
 

--- a/bitcart/coins/btc.py
+++ b/bitcart/coins/btc.py
@@ -539,6 +539,18 @@ class BTC(Coin, EventDelivery):
         return await self.server.add_peer(connection_string)  # type: ignore
 
     @lightning
+    async def list_peers(self, gossip: bool = False) -> list:
+        """Get a list of lightning peers
+
+        Args:
+            gossip (bool, optional): Whether to return peers of a gossip (one per node) or of a wallet. Defaults to False.
+
+        Returns:
+            list: list of lightning peers
+        """
+        return await self.server.list_peers(gossip=gossip)  # type: ignore
+
+    @lightning
     async def list_channels(self) -> list:
         """List all channels ever opened
 

--- a/bitcart/errors.py
+++ b/bitcart/errors.py
@@ -13,10 +13,6 @@ class LightningDisabledError(BaseError):
     """Lightning is disabled in daemon"""
 
 
-class WebhookUnsupportedError(BaseError):
-    """Webhook support not installed"""
-
-
 class ConnectionFailedError(BaseError):
     """Error connecting to the daemon"""
 

--- a/bitcart/event_delivery.py
+++ b/bitcart/event_delivery.py
@@ -3,24 +3,15 @@ import logging
 from json import JSONDecodeError
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Optional, Union
 
-from .errors import WebhookUnsupportedError
+from aiohttp import web
 
 if TYPE_CHECKING:
     from providers.jsonrpcrequests import RPCProxy
-
-webhook_available = True
-try:
-    from aiohttp import web
-except (ModuleNotFoundError, ImportError):  # pragma: no cover
-    webhook_available = False
 
 
 class EventDelivery:
     server: "RPCProxy"
     event_handlers: Dict[str, Callable]
-
-    def __init__(self) -> None:
-        self.webhook_available = webhook_available
 
     async def handle_webhook(self, request: "web.Request") -> "web.Response":
         try:
@@ -39,17 +30,12 @@ class EventDelivery:
         self.webhook_app = web.Application()
         self.webhook_app.router.add_post("/", self.handle_webhook)
 
-    def check_webhook_support(self) -> None:
-        if not webhook_available:
-            raise WebhookUnsupportedError("Webhook support not installed. Install it with pip install bitcart[webhook]")
-
     async def _configure_notifications(self, autoconfigure: bool = True) -> None:
         await self.server.subscribe(list(self.event_handlers.keys()))
         if autoconfigure:
             await self.server.configure_notifications("http://localhost:6000")
 
     async def configure_webhook(self, autoconfigure: bool = True) -> None:
-        self.check_webhook_support()
         self._configure_webhook()
         await self._configure_notifications(autoconfigure=autoconfigure)
 
@@ -57,7 +43,6 @@ class EventDelivery:
         web.run_app(self.webhook_app, port=port, **kwargs)
 
     def start_webhook(self, port: int = 6000, **kwargs: Any) -> None:
-        self.check_webhook_support()
         self.configure_webhook()
         self._start_webhook(port=port, **kwargs)
 

--- a/bitcart/event_delivery.py
+++ b/bitcart/event_delivery.py
@@ -61,7 +61,7 @@ class EventDelivery:
         self.configure_webhook()
         self._start_webhook(port=port, **kwargs)
 
-    async def poll_updates(self, timeout: Union[int, float] = 2) -> None:  # pragma: no cover
+    async def poll_updates(self, timeout: Union[int, float] = 1) -> None:  # pragma: no cover
         """Poll updates
 
         Poll daemon for new transactions in wallet,
@@ -71,7 +71,7 @@ class EventDelivery:
 
         Args:
             self (BTC): self
-            timeout (Union[int, float], optional): seconds to wait before requesting transactions again. Defaults to 2.
+            timeout (Union[int, float], optional): seconds to wait before requesting transactions again. Defaults to 1.
 
         Raises:
             InvalidEventError: If server sent invalid event name not matching ALLOWED_EVENTS

--- a/bitcart/sync.py
+++ b/bitcart/sync.py
@@ -21,6 +21,8 @@ def run_sync_ctx(coroutine: Any, loop: asyncio.AbstractEventLoop) -> Any:
     if inspect.isasyncgen(coroutine):
         return loop.run_until_complete(consume_generator(coroutine))
 
+    return coroutine
+
 
 def async_to_sync_wraps(function: Callable, is_property: bool = False) -> Callable:
     main_loop = asyncio.get_event_loop()
@@ -46,7 +48,7 @@ def async_to_sync_wraps(function: Callable, is_property: bool = False) -> Callab
                 if inspect.isasyncgen(coroutine):
                     return asyncio.run_coroutine_threadsafe(consume_generator(coroutine), loop).result()
 
-        return run_sync_ctx(coroutine, loop) or coroutine
+        return run_sync_ctx(coroutine, loop)
 
     result = async_to_sync_wrap
     if is_property:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -77,3 +77,12 @@ calling lightning methods.
     :members:
     :show-inheritance:
     :undoc-members:
+
+Utilities
+*****************
+
+.. automodule:: bitcart.utils
+    :members:
+    :show-inheritance:
+    :undoc-members:
+    :exclude-members: CustomJSONEncoder

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,7 +58,7 @@ Supported coins list(⚡ means lightning is supported):
 
 To use proxy, install optional dependencies:
 
-``pip install bitcart[proxy]`` for sync version, ``pip install bitcart-async[proxy]`` for async version.
+``pip install bitcart[proxy]``
 HTTP, SOCKS4 and SOCKS5 proxies supported.
 
 To use, pass proxy url to coin constructor:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,19 +9,6 @@ Simply run
 
 to install the library.
 
-Or, run
-
-.. code-block:: sh
-
-    pip install bitcart-async
-
-To install async version of the library.
-
-You can't install both.
-
-Async version of the library has the same API, but is intended to be used in asyncio application.
-All is the same, just use async/await.
-
 But to initialize bitcoin instance you will need
 ``rpc_url``, ``rpc_login`` and ``rpc_password`` (not required, defaults
 work with default ports and authentification).
@@ -42,7 +29,7 @@ Run ``pip install -r requirements/daemons/coin_name.txt`` to install
 requirements for daemon of ``coin_name``.
 
 This will clone main BitcartCC repo and install dependencies,
-we recommend using virtualenv for consistency.(some daemons conflict one
+we recommend using virtualenv for consistency(some daemons conflict one
 with another, so using one virtualenv per daemon is fine).
 
 To run daemon, just start it:

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,5 +10,7 @@ Examples:
 - Get transaction by tx hash(CLI): gettx.py
 - Get wallet onchain and offchain(lightning) balance: getbalance.py
 - Pay to some address(CLI): donateto.py
+- Webhook example: webhook.py
+- APIManager example: manager.py
 
 Full example(telegram bot) is available at atomic_tipbot directory

--- a/examples/full.py
+++ b/examples/full.py
@@ -62,6 +62,7 @@ print(btc2.node_id)  # your lightning node id(lightning daemon is bitcart daemon
 print(btc2.add_invoice(0.5, "Description"))  # create lightning invoice
 # print(btc2.connect("some connection string"))  # add new lightning peer, connect
 # print(btc2.open_channel("some node id", 0.5))  # open lightning channel with node
+print(btc2.list_peers())  # list of lightning peers
 print(btc2.list_channels())  # List of lightning channels
 # print(btc2.close_channel("channel id"))  # Close channel by channel id, set force to True to do force-close
 # print(btc2.lnpay("lightning invoice here"))  # pay a lightning invoice

--- a/examples/full.py
+++ b/examples/full.py
@@ -59,7 +59,7 @@ if DONATE_TO_AUTHOR:
 
 # Lightning(requires wallet) #
 print(btc2.node_id)  # your lightning node id(lightning daemon is bitcart daemon itself)
-print(btc2.addinvoice(0.5, "Description"))  # create lightning invoice
+print(btc2.add_invoice(0.5, "Description"))  # create lightning invoice
 # print(btc2.connect("some connection string"))  # add new lightning peer, connect
 # print(btc2.open_channel("some node id", 0.5))  # open lightning channel with node
 print(btc2.list_channels())  # List of lightning channels

--- a/tests/coins/btc/test_lightning.py
+++ b/tests/coins/btc/test_lightning.py
@@ -48,6 +48,6 @@ async def test_lightning_disabled(btc_wallet):
     await btc_wallet.set_config("lightning", True)  # reset back
 
 
-async def test_wallet_methods_on_non_segwit(btc_wallet):
+async def test_wallet_methods_on_non_segwit(lightning_unsupported_wallet):
     with pytest.raises(errors.LightningUnsupportedError):
-        await btc_wallet.list_channels()  # unsupported on non-segwit wallets
+        await lightning_unsupported_wallet.list_channels()  # unsupported on non-segwit wallets

--- a/tests/coins/btc/test_lightning.py
+++ b/tests/coins/btc/test_lightning.py
@@ -41,6 +41,23 @@ async def test_connect(btc_wallet):
     assert await btc_wallet.connect("0214382bdce7750dfcb8126df8e2b12de38536902dc36abcebdaeefdeca1df8284@172.81.181.3")
 
 
+async def test_list_peers(btc_wallet):
+    res1 = await btc_wallet.list_peers()
+    res2 = await btc_wallet.list_peers(True)
+    assert isinstance(res1, list)
+    assert isinstance(res2, list)
+    assert len(res1) > 0
+    assert len(res2) > 0
+    peer = res1[0]
+    assert peer.keys() == {"node_id", "address", "initialized", "features", "channels"}
+    assert peer["initialized"]
+    data_check(peer, "node_id", str, 66)
+    data_check(peer, "address", str)
+    data_check(peer, "features", str)
+    assert "LnFeatures." in peer["features"]
+    data_check(peer, "channels", list, 0)
+
+
 async def test_lightning_disabled(btc_wallet):
     await btc_wallet.set_config("lightning", False)
     with pytest.raises(LightningDisabledError):

--- a/tests/coins/btc/test_without_wallet.py
+++ b/tests/coins/btc/test_without_wallet.py
@@ -63,7 +63,7 @@ async def test_validate_key(btc, key, expected):
 
 async def test_get_tx(btc):
     info = await btc.get_tx("0584c650e7b04cd0788832f8340ead4ce654e82127e283c8132a0bcbfabc7a01")
-    assert info.items() > {"partial": False, "version": 1, "segwit_ser": True, "lockTime": 0}.items()
+    assert info.items() > {"version": 1, "locktime": 0}.items()
     data_check(info, "confirmations", int)
     assert info["confirmations"] > 0
     data_check(info, "inputs", list, 1)
@@ -72,11 +72,9 @@ async def test_get_tx(btc):
         >= {
             "prevout_hash": "f5bec7770c30679bd7e91ecc3cf243d43c5a72b28ac8e037eb8c1b5bfe520e27",
             "prevout_n": 0,
+            "coinbase": False,
             "scriptSig": "",
-            "sequence": 4294967295,
-            "type": "unknown",
-            "address": None,
-            "num_sig": 0,
+            "nsequence": 4294967295,
             "witness": (
                 "02473044022030f19cf4b53b0c5d7a9d920240f6daab0cf8a40193f80a8"
                 "0d40635dc0ca213af0220487e8714a082f22dba14733f1149bd365767702"
@@ -87,11 +85,9 @@ async def test_get_tx(btc):
     )
     data_check(info, "outputs", list, 2)
     assert info["outputs"][0] == {
-        "value": 490000,
-        "type": 0,
+        "value_sats": 490000,
         "address": "3NyLhw2jKrA8PF2SqgGQu4cigfCg1i6SqH",
-        "scriptPubKey": "a914e970f9ca2f7d99b208b455333b0a4ab2b9b7eb3a87",
-        "prevout_n": 0,
+        "scriptpubkey": "a914e970f9ca2f7d99b208b455333b0a4ab2b9b7eb3a87",
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from bitcart.coin import Coin
 
 TEST_XPUB = "xprv9s21ZrQH143K3tZPHG8CbfZ7uUY5stdHmaEXeSqawGrZuAoBdHPgKHjdkfmHSdxDJSbo29JiU1PcWhzEsgFryqMHQfr2T5TWBPK8EqFjscZ"
 REGTEST_XPUB = (
-    "tprv8ZgxMBicQKsPepFfedsYPCgWioGqkbnRbMmprdTq3jFmRf7JQwe3Yo8DMBwttKFNLpp3xVx6Rfv7ChxZbkLXgnmb8hcq4uN2hVKLmCNcTpB"
+    "vprv9DMUxX4ShgxMMQduKMSnoNsX4jZjdqmRRapGRRFbok1XXrjkvFyAnvSVPbs4t8ZDA73fTT9DLzdCyHBh39AZHG8nsP1gEj11EwSdYP8zhKF"
 )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,11 @@ async def regtest_wallet():
 
 
 @pytest.fixture
+async def regtest_node_id():
+    return await BTC(xpub=REGTEST_XPUB, rpc_url="http://localhost:5110").node_id
+
+
+@pytest.fixture
 async def btc():
     with warnings.catch_warnings():  # to ignore no xpub passed warning
         warnings.simplefilter("ignore")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,12 @@ import pytest
 from bitcart import BTC
 from bitcart.coin import Coin
 
-TEST_XPUB = "xprv9s21ZrQH143K3tZPHG8CbfZ7uUY5stdHmaEXeSqawGrZuAoBdHPgKHjdkfmHSdxDJSbo29JiU1PcWhzEsgFryqMHQfr2T5TWBPK8EqFjscZ"
+TEST_XPUB = "zprvAWgYBBk7JR8GkUwcwyhT1qk8FQpym8cHboGyDEdMhHcL1NRe8bioZR3uo5gTSTG47iqQX6VqPL6iHHDNK55taJiV9MEscu6UiqSR1tAiSUq"
 REGTEST_XPUB = (
     "vprv9DMUxX4ShgxMMQduKMSnoNsX4jZjdqmRRapGRRFbok1XXrjkvFyAnvSVPbs4t8ZDA73fTT9DLzdCyHBh39AZHG8nsP1gEj11EwSdYP8zhKF"
+)
+LIGHTNING_UNSUPPORTED_XPUB = (
+    "xprv9s21ZrQH143K3tZPHG8CbfZ7uUY5stdHmaEXeSqawGrZuAoBdHPgKHjdkfmHSdxDJSbo29JiU1PcWhzEsgFryqMHQfr2T5TWBPK8EqFjscZ"
 )
 
 
@@ -31,6 +34,11 @@ async def btc_nowallet():
 @pytest.fixture
 async def btc_wallet():
     return BTC(xpub=TEST_XPUB)
+
+
+@pytest.fixture
+async def lightning_unsupported_wallet():
+    return BTC(xpub=LIGHTNING_UNSUPPORTED_XPUB)
 
 
 @pytest.fixture

--- a/tests/regtest.py
+++ b/tests/regtest.py
@@ -110,9 +110,8 @@ async def test_open_channel(regtest_wallet, regtest_node_id, wait_for_utxos):
     run_shell(["newblocks", "3"])
 
 
-async def test_list_channels(regtest_wallet):
-    node_id = await regtest_wallet.node_id
-    pubkey = node_id.split("@")[0]
+async def test_list_channels(regtest_wallet, regtest_node_id):
+    pubkey = regtest_node_id.split("@")[0]
     result = await regtest_wallet.list_channels()
     assert isinstance(result, list)
     assert len(result) > 0


### PR DESCRIPTION
This PR makes necessary changes to SDK to work with electrum 4.0
Daemon PR: bitcartcc/bitcart#123

Some changes in SDK in this PR:
- `onchain_history` now doesn't need to be json.load'ed, this bug was fixed. SDK update will make it seamless
- `addinvoice` renamed to `add_invoice` (breaking)
- `poll_updates` timeout before re-fetching new updates decreased from 2 to 1 second

Breaking changes since last electrum version, documented here:
- `pay_to`/`pay_to_many`, with broadcast=False now returns str instead of a dict, removing redundant keys. It now returns raw transaction directly.
-  `add_invoice` now returns a dictionary instead of str
    Before it returned lightning invoice itself, now it returns payment request dict for lightning, where invoice is in `invoice` key
    dict structure:
    ```
    {
        "is_lightning": True,
        "amount_BTC": "0.5",
        "message": "test description",
        "expiration": 3600,
        "status": 0,
        "status_str": "Expires in about 1 hour",
        "amount_msat": 50000000000,
        "can_receive": False,
    }
    ```
    plus `timestamp` key (int), `rhash` (str) and `invoice` (str)
- On non-segwit wallets, `errors.LightningUnsupportedError` will be raised now
- `add_request`/`get_request` structure changed:
    - `memo` key renamed to `message` (payment request description)
    - `amount` key to `amount_sat` (amount in satoshis)
    - new `is_lightning` key, which will be `False` on payment requests
- `get_tx` output format changed:
    - removed `partial` and `segwit_ser` keys
    - `lockTime` renamed to `locktime`
    - inputs format changes:
        - added `coinbase` key (bool)
        - renamed `sequence` to `nsequence`
        - removed `type`, `address` and `num_sig` keys
    - outputs format changes:
        - `scriptPubKey` renamed to `scriptpubkey`
        - `value` renamed to `value_sats`
        - removed `prevout_n` and `type` keys
- `list_channels` output format changed:
    - items are now ordered, last channel is last in the list
    - channel format changes:
        - `channel_id` renamed to `short_channel_id`
        - `full_channel_id` renamed to `channel_id`
        - added new `peer_state` key (str)
        - removed `local_htlcs` and `remote_htlcs`
        - added `local_reserve` (int), `remote_reserve` (int), `local_unsettled_sent` (int) and `remote_unsettled_sent` (int) keys
- `lnpay` output changed:
    - It doesn't raise `NoPathFoundError` or any other errors anymore
    - It now returns a dict with keys `success` (bool), `preimage` (Optional[str]) and `log` (list of lists of strings)

Some current issues:
- After many pay_to, open_channel seems to be not working at all, large sleep interval > 5 seconds is needed. It returns insufficient funds even when there are enough funds. (done)
- close_channel raises error `Failed to verify our signature`, only force-close works. (done)

TODO:
- [ ] Create a changelog by using [this compare url](https://github.com/bitcartcc/bitcart-sdk/compare/0.9.1...electrum-4.0.3)