### PR TITLE
Upgrade electrums

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
     parameters:
       v:
         type: string
-        default: "3.7"
+        default: "3.8"
 
     docker:
       - image: cimg/python:<< parameters.v >>
@@ -100,7 +100,7 @@ jobs:
   deploy:
     executor: bitcartcc/docker-python
     docker:
-      - image: cimg/python:3.7
+      - image: cimg/python:3.8
     steps:
       - checkout
 
@@ -134,7 +134,6 @@ workflows:
           matrix:
             parameters:
               v:
-                - "3.7"
                 - "3.8"
                 - "3.9"
                 - "3.10"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ commands:
       - run:
           name: clone daemon
           command: |
-            git clone https://github.com/bitcartcc/bitcart ~/bitcart-daemon
+            git clone https://github.com/bitcartcc/bitcart -b electrum-upgrade ~/bitcart-daemon
 
       - restore_cache:
           keys:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     rev: v2.34.0
     hooks:
       - id: pyupgrade
-        args: ["--py37-plus"]
+        args: ["--py38-plus"]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Latest changes
 
+## 1.10.0.0
+
+We now support Python >= 3.8 only
+
+Updates to support electrum 4.3.0
+
 ## 1.9.3.0
 
 SDK no longer requires all event parameters to be present in handlers: it will detect which ones to pass by name.

--- a/bitcart/coins/btc.py
+++ b/bitcart/coins/btc.py
@@ -544,7 +544,7 @@ class BTC(Coin, EventDelivery):
         Returns:
             dict: Invoice data
         """
-        return await self._add_request_base(self.server.add_lightning_request, amount, description, expire)
+        return await self.add_request(amount, description, expire)
 
     @lightning
     async def close_channel(self, channel_id: str, force: bool = False) -> str:

--- a/bitcart/errors.py
+++ b/bitcart/errors.py
@@ -37,7 +37,7 @@ class NotImplementedError(RequestError):
     """Not implemented"""
 
 
-@functools.lru_cache()
+@functools.lru_cache
 def generate_exception(exc_name: str) -> type:
     return type(exc_name, (RequestError,), {})
 

--- a/examples/atomic_tipbot/README.md
+++ b/examples/atomic_tipbot/README.md
@@ -4,7 +4,7 @@ The bot is available in telegram at @bitcart_atomic_tipbot
 
 Used tools:
 
-- Python 3.7+
+- Python 3.8+
 - Mongo DB
 - Pyrogram(for bot)
 - qrcode library for generating qr codes
@@ -15,7 +15,7 @@ This bot is rewritten in my style, using modern python 3.6+ f-strings, and of co
 
 ## Installation
 
-To get started, you will need to have [Python 3.7+](https://python.org) installed, of course. Using virtualenv is recommended.
+To get started, you will need to have [Python 3.8+](https://python.org) installed, of course. Using virtualenv is recommended.
 Install Mongo DB using it's installation [guide](https://docs.mongodb.com/manual/administration/install-community)
 After that, install dependencies of this example using:
 
@@ -70,7 +70,7 @@ If you will later need to stop them, run `./stop.sh`
 
 ### Manual way
 
-As for this example, Python 3.7+ is required. Using virtualenv is recommended.
+As for this example, Python 3.8+ is required. Using virtualenv is recommended.
 
 Clone BitcartCC repository:
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 setup(
     name="bitcart",
     packages=find_packages(),
-    version="1.9.3.0",
+    version="1.10.0.0",
     license="LGPLv3+",
     description="BitcartCC coins support library",
     long_description=open("README.md").read(),

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,9 @@ setup(
         "Topic :: Software Development :: Build Tools",
         "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],
+    python_requires=">=3.8",
 )

--- a/tests/coins/btc/test_with_wallet.py
+++ b/tests/coins/btc/test_with_wallet.py
@@ -41,18 +41,19 @@ async def test_payment_request(btc_wallet):
     assert (
         request1.items()
         > {
-            "is_lightning": False,
+            "is_lightning": True,
             "amount_BTC": Decimal("0.5"),
             "message": "",
-            "expiration": 900,
             "status": 0,
             "status_str": "Expires in 15 minutes",
             "amount_sat": 50000000,
         }.items()
     )
     data_check(request1, "timestamp", int)
+    data_check(request1, "expiration", int)
     data_check(request1, "address", str)
     data_check(request1, "URI", str)
+    assert request1["expiration"] - request1["timestamp"] == 900
 
 
 async def test_insufficient_funds_pay(btc_wallet):

--- a/tests/regtest.py
+++ b/tests/regtest.py
@@ -162,7 +162,7 @@ async def test_list_channels(regtest_wallet, regtest_node_id):
 async def test_lnpay(regtest_wallet, regtest_node):
     with pytest.raises(errors.InvalidLightningInvoiceError):
         assert not await regtest_wallet.lnpay("")
-    invoice = (await regtest_node.add_invoice(0.01))["invoice"]
+    invoice = (await regtest_node.add_invoice(0.01))["lightning_invoice"]
     response = await regtest_wallet.lnpay(invoice)
     assert isinstance(response, dict)
     assert response.keys() == {"payment_hash", "success", "preimage", "log"}


### PR DESCRIPTION
Fixes in order to upgrade electrums: bitcartcc/bitcart#296

API changes:
- `add_request, get_request` are now for unified LN and onchain payments. `add_invoice` is an alias for `add_request`.
- For LN invoices, the actual LN invoice field is renamed from `invoice` to `lightning_invoice`
- For all payment requests, `expiration` field is no longer the time invoice will be valid (i.e. 900 seconds), but the unix (absolute) timestamp of when it will expire. The old value can be calculated as `request['expiration'] - request['timestamp']`