### PR TITLE
Add XRP coin support

### DIFF
--- a/bitcart/__init__.py
+++ b/bitcart/__init__.py
@@ -1,6 +1,6 @@
 from universalasync import wrap
 
-from .coins import BCH, BNB, BTC, COINS, ETH, GRS, LTC, MATIC, TRX, XMR, XRG  # noqa: F401
+from .coins import BCH, BNB, BTC, COINS, ETH, GRS, LTC, MATIC, TRX, XMR, XRG, XRP  # noqa: F401
 from .errors import errors
 from .manager import APIManager
 from .providers.jsonrpcrequests import RPCProxy

--- a/bitcart/coins/__init__.py
+++ b/bitcart/coins/__init__.py
@@ -8,6 +8,7 @@ from .matic import MATIC
 from .trx import TRX
 from .xmr import XMR
 from .xrg import XRG
+from .xrp import XRP
 
 COINS = {
     "BTC": BTC,
@@ -20,6 +21,7 @@ COINS = {
     "TRX": TRX,
     "XRG": XRG,
     "GRS": GRS,
+    "XRP": XRP,
 }
 
 __all__ = list(COINS.keys()) + ["COINS"]

--- a/bitcart/coins/xrp.py
+++ b/bitcart/coins/xrp.py
@@ -5,4 +5,4 @@ class XRP(ETH):
     coin_name = "XRP"
     friendly_name = "XRP"
     RPC_URL = "http://localhost:5012"
-    is_eth_based = False
+    is_eth_based = True

--- a/bitcart/coins/xrp.py
+++ b/bitcart/coins/xrp.py
@@ -1,0 +1,7 @@
+from .eth import ETH
+
+
+class XRP(ETH):
+    coin_name = "XRP"
+    friendly_name = "XRP"
+    RPC_URL = "http://localhost:5012"

--- a/bitcart/coins/xrp.py
+++ b/bitcart/coins/xrp.py
@@ -5,3 +5,4 @@ class XRP(ETH):
     coin_name = "XRP"
     friendly_name = "XRP"
     RPC_URL = "http://localhost:5012"
+    is_eth_based = False


### PR DESCRIPTION
Adds XRP coin class to the SDK, extending ETH (account-based model).

- `is_eth_based = True` for correct wallet creation and payout API routing
- RPC default: `http://localhost:5012`

Companion PR to the main bitcart daemon XRP integration.