### PR TITLE
Add SUI SDK client support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Coins support(⚡ means lightning is supported):
 - Ethereum
 - Binance coin (BNB)
 - Polygon (MATIC)
+- Sui (SUI)
 - Tron (TRX)
 - Ergon
 - Litecoin (⚡)

--- a/bitcart/__init__.py
+++ b/bitcart/__init__.py
@@ -1,6 +1,6 @@
 from universalasync import wrap
 
-from .coins import BCH, BNB, BTC, COINS, ETH, GRS, LTC, MATIC, TRX, XMR, XRG  # noqa: F401
+from .coins import BCH, BNB, BTC, COINS, ETH, GRS, LTC, MATIC, SUI, TRX, XMR, XRG  # noqa: F401
 from .errors import errors
 from .manager import APIManager
 from .providers.jsonrpcrequests import RPCProxy

--- a/bitcart/coins/__init__.py
+++ b/bitcart/coins/__init__.py
@@ -5,6 +5,7 @@ from .eth import ETH
 from .grs import GRS
 from .ltc import LTC
 from .matic import MATIC
+from .sui import SUI
 from .trx import TRX
 from .xmr import XMR
 from .xrg import XRG
@@ -17,6 +18,7 @@ COINS = {
     "BNB": BNB,
     "LTC": LTC,
     "MATIC": MATIC,
+    "SUI": SUI,
     "TRX": TRX,
     "XRG": XRG,
     "GRS": GRS,

--- a/bitcart/coins/sui.py
+++ b/bitcart/coins/sui.py
@@ -1,0 +1,9 @@
+from .eth import ETH
+
+
+class SUI(ETH):
+    coin_name = "SUI"
+    xpub_name = "Address"
+    friendly_name = "Sui"
+    RPC_URL = "http://localhost:5012"
+    is_eth_based = False

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -42,6 +42,12 @@ Polygon (MATIC) support is based on our custom daemon implementation which tries
 
 ::: bitcart.coins.matic.MATIC
 
+### Sui (SUI)
+
+Sui (SUI) support is based on our custom daemon implementation which tries to follow electrum APIs as closely as possible
+
+::: bitcart.coins.sui.SUI
+
 ### TRON (TRX)
 
 TRON (TRX) support is based on our custom daemon implementation which tries to follow electrum APIs as closely as possible

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -41,6 +41,7 @@ Supported coins list (:zap: means lightning is supported):
 - Ethereum
 - Binance coin (BNB)
 - Polygon (MATIC)
+- Sui (SUI)
 - Tron (TRX)
 - Ergon
 - Litecoin (:zap:)

--- a/tests/coins/test_sui.py
+++ b/tests/coins/test_sui.py
@@ -1,0 +1,29 @@
+import bitcart
+from bitcart import COINS, SUI
+from bitcart.manager import APIManager
+
+SUI_ADDRESS = "0x" + "1" * 64
+SUI_RPC_URL = "http://localhost:5012"
+
+
+def test_sui_is_registered():
+    assert COINS["SUI"] is SUI
+    assert bitcart.SUI is SUI
+    assert "SUI" in bitcart.__all__
+
+
+def test_sui_defaults():
+    sui = SUI()
+
+    assert sui.coin_name == "SUI"
+    assert sui.friendly_name == "Sui"
+    assert sui.rpc_url == SUI_RPC_URL
+    assert sui.xpub_name == "Address"
+    assert sui.EXPIRATION_KEY == "expiration"
+    assert sui.is_eth_based is False
+
+
+def test_manager_loads_sui_wallet():
+    manager = APIManager({"SUI": [SUI_ADDRESS]})
+
+    assert manager.wallets["SUI"][SUI_ADDRESS] == SUI(xpub=SUI_ADDRESS)


### PR DESCRIPTION
## Summary

Adds a SUI SDK coin client so Bitcart API consumers can import and register SUI like the other built-in coins.

## Changes

- Add `bitcart.coins.sui.SUI` with the default daemon URL on port `5012`
- Export `SUI` from `bitcart.coins`, top-level `bitcart`, and `COINS`
- Document SUI in the supported coin lists
- Add registration/defaults tests for the SUI client

## Notes

- Native SUI daemon PR: https://github.com/bitcart/bitcart/pull/589
- Sui `Coin<T>` token support is intentionally left for a later PR.

## Validation

- `uv run pytest tests\coins\test_sui.py -q -o addopts=`
- `uv run pytest tests\coins\test_sui.py -q`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy bitcart`
- `uv run deptry .`