### PR TITLE
Add Ethereum on Arbitrum (ARBETH) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Latest changes
 
+Add Ethereum on Arbitrum (ARBETH) support
+
 ## 1.19.1.2
 
 Include PEP740 digital attestations with release

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Coins support(⚡ means lightning is supported):
 - Ethereum
 - Binance coin (BNB)
 - Polygon (MATIC)
+- Ethereum on Arbitrum (ARBETH)
 - Tron (TRX)
 - Ergon
 - Litecoin (⚡)

--- a/bitcart/__init__.py
+++ b/bitcart/__init__.py
@@ -1,6 +1,6 @@
 from universalasync import wrap
 
-from .coins import BCH, BNB, BTC, COINS, ETH, GRS, LTC, MATIC, TRX, XMR, XRG  # noqa: F401
+from .coins import ARBETH, BCH, BNB, BTC, COINS, ETH, GRS, LTC, MATIC, TRX, XMR, XRG  # noqa: F401
 from .errors import errors
 from .manager import APIManager
 from .providers.jsonrpcrequests import RPCProxy

--- a/bitcart/coins/__init__.py
+++ b/bitcart/coins/__init__.py
@@ -1,3 +1,4 @@
+from .arbeth import ARBETH
 from .bch import BCH
 from .bnb import BNB
 from .btc import BTC
@@ -20,6 +21,7 @@ COINS = {
     "TRX": TRX,
     "XRG": XRG,
     "GRS": GRS,
+    "ARBETH": ARBETH,
 }
 
 __all__ = list(COINS.keys()) + ["COINS"]

--- a/bitcart/coins/arbeth.py
+++ b/bitcart/coins/arbeth.py
@@ -1,0 +1,7 @@
+from .eth import ETH
+
+
+class ARBETH(ETH):
+    coin_name = "ARBETH"
+    friendly_name = "Ethereum (Arbitrum)"
+    RPC_URL = "http://localhost:5012"

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -42,6 +42,12 @@ Polygon (MATIC) support is based on our custom daemon implementation which tries
 
 ::: bitcart.coins.matic.MATIC
 
+### Ethereum on Arbitrum (ARBETH)
+
+Ethereum on Arbitrum (ARBETH) support is based on our custom daemon implementation which tries to follow electrum APIs as closely as possible
+
+::: bitcart.coins.arbeth.ARBETH
+
 ### TRON (TRX)
 
 TRON (TRX) support is based on our custom daemon implementation which tries to follow electrum APIs as closely as possible

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -41,6 +41,7 @@ Supported coins list (:zap: means lightning is supported):
 - Ethereum
 - Binance coin (BNB)
 - Polygon (MATIC)
+- Ethereum on Arbitrum (ARBETH)
 - Tron (TRX)
 - Ergon
 - Litecoin (:zap:)


### PR DESCRIPTION
## What

Adds an `ARBETH` coin class for Ethereum on Arbitrum One, mirroring the existing `MATIC` class: `coin_name = "ARBETH"`, `friendly_name = "Ethereum (Arbitrum)"`, default RPC URL `http://localhost:5012`. Registered in `COINS` and the package imports; docs and changelog updated.

## Why ARBETH and not ARB

Arbitrum's native gas currency is ETH — ARB is only an ERC-20 governance token. Since the coin name doubles as the currency ticker across bitcart (exchange rates, money formatting, invoices) and `ETH` is taken by mainnet, `ARBETH` names the asset honestly. The ARB token is offered as a regular ERC-20 token in the daemon's token list instead.

## Testing

- `ARBETH` import/instantiation verified (`coin_name`, `friendly_name`, `COINS` registration).
- Full test suite (everything except `tests/regtest`, which needs a regtest bitcoind): **60/60 passing** against a live BTC testnet daemon, mirroring the CI setup.
- End-to-end against a live ARBETH daemon on Arbitrum Sepolia: `getinfo` connected, seed → wallet → zero balance → `add_request` returning `ethereum:0x…@421614?value=…`.

## Companion PRs

Daemon-side support lands in the companion bitcart PR (bitcart/bitcart#618: daemon + token list + config registrations); deployment support in bitcart/bitcart-docker#51. This SDK PR is the prerequisite: bitcart's API imports `COINS` from this package, so the coin can only be enabled there once a release includes this change.